### PR TITLE
s2: camera: only allow initStaticMetadata when fully ready

### DIFF
--- a/camera/QCamera2/HAL3/QCamera3HWI.cpp
+++ b/camera/QCamera2/HAL3/QCamera3HWI.cpp
@@ -5207,6 +5207,16 @@ void QCamera3HardwareInterface::patchCaps()
  *==========================================================================*/
 int QCamera3HardwareInterface::initStaticMetadata(uint32_t cameraId)
 {
+	if(!gCamCapability[cameraId]->picture_sizes_tbl_cnt){
+		ALOGW("initStaticMetadata(): picture_sizes_tbl_cnt is null! Return NO_ERROR code and allow it to properly initalize");
+		return NO_ERROR;
+		
+	}
+	if(gCamCapability[cameraId]->picture_sizes_tbl_cnt < 5){ // In theory it should always == 13, but lets set it to under 5 for security
+		ALOGW("initStaticMetadata(): picture_sizes_tbl_cnt equals %d! Return NO_ERROR code and allow it to properly initalize", (int) gCamCapability[cameraId]->picture_sizes_tbl_cnt);
+		return NO_ERROR;
+	}
+	
     int rc = 0;
     CameraMetadata staticInfo;
     size_t count = 0;


### PR DESCRIPTION
Some GSIs call initStaticMetadata before they really should, only to
later call it again. This causes null pointer dereference causing system
to not boot. Example
https://gist.github.com/nullbytepl/59cef6ba30802ad672922a35e46d40cb

To fix this only allow running this function when gCamCapability is
populated. Otherwise return NO_ERROR.